### PR TITLE
Set the tag namespace

### DIFF
--- a/lib/amazon/parser/vm.rb
+++ b/lib/amazon/parser/vm.rb
@@ -48,7 +48,7 @@ module Amazon
         tags.each do |tag|
           collections[:vm_tags].data << TopologicalInventoryIngressApiClient::VmTag.new(
             :vm    => lazy_find(:vms, :source_ref => vm_uid),
-            :tag   => lazy_find(:tags, :name => tag.key),
+            :tag   => lazy_find(:tags, :name => tag.key, :namespace => "amazon"),
             :value => tag.value,
           )
         end


### PR DESCRIPTION
When the persister doesn't auto-set this from the source_type we'll need
to send it.